### PR TITLE
feat: add token-aware chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A GitHub Action that automatically translates Korean markdown documents to Engli
 - **Auto PR Creation**: Automatically creates pull requests with translations
 - **Smart Skipping**: Skip files that are already translated and up-to-date
 - **Retry Logic**: Built-in retry mechanism for robust API calls
+- **Token-aware Chunking**: Splits long documents by token length to avoid truncation
 
 ## 📋 Prerequisites
 


### PR DESCRIPTION
## Summary
- add optional tiktoken-based token counting helpers
- split long markdown files by token limit to prevent truncated translations
- document token-aware chunking feature

## Testing
- `python -m py_compile entrypoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2dcb61864832c9e4ff375e693be50