### PR TITLE
refactor: use token-aware chunking for translations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     && apt-get install -y gh
 
 # Install Python dependencies
-RUN pip install --no-cache-dir requests
+RUN pip install --no-cache-dir requests tiktoken
 
 # Copy the entrypoint script
 COPY entrypoint.py /entrypoint.py


### PR DESCRIPTION
## Summary
- count tokens with tiktoken for accurate context limits
- split markdown by paragraph tokens and respect file patterns
- install tiktoken in the action Docker image

## Testing
- `python -m py_compile entrypoint.py`


------
https://chatgpt.com/codex/tasks/task_e_68b83876aac4832c97213d5a3278e65c